### PR TITLE
add sabre in mapping and routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Quantum Science and Technology, 2016
 + [Not All Qubits Are Created Equal: A Case for Variability-Aware Policies for NISQ-Era Quantum Computers](https://dl.acm.org/doi/10.1145/3297858.3304007) - Swamit S. Tannu, Moinuddin K. Qureshi, ASPLOS, 2019
 + [Paulihedral: a generalized block-wise compiler optimization framework for Quantum simulation kernels](https://arxiv.org/abs/1901.11054) - Prakash Murali, Jonathan M. Baker, Ali Javadi Abhari, Frederic T. Chong, Margaret Martonosi, ASPLOS, 19
 + [Noise-adaptive compiler mappings for noisy intermediate-scale quantum computers.](https://arxiv.org/abs/1901.11054) - Prakash Murali, Jonathan M. Baker, Ali Javadi Abhari, Frederic T. Chong, Margaret Martonosi, ASPLOS, 2019
++ [Tackling the Qubit Mapping Problem for NISQ-Era Quantum Devices](https://dl.acm.org/doi/abs/10.1145/3297858.3304023) - Gushu Li, Yufei Ding, and Yuan Xie, ASPLOS, 2019
 
 
 


### PR DESCRIPTION
Hi,

Thanks for this great collection! 

In this PR, I wish to add an early paper for qubit mapping: https://dl.acm.org/doi/abs/10.1145/3297858.3304023, it introduced SABRE, which is widely used and adopted by IBM qiskit framework. 